### PR TITLE
Add Sencrop API

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Contributions welcome! Please follow the [contributing guidelines](https://githu
 - [MyJohnDeereAPI-OAuth-Python3-Client](https://github.com/JohnDeere/MyJohnDeereAPI-OAuth-Python3-Client) - Python3 MyJohnDeere API client implementation.
 - [MyJohnDeereAPI-OAuth-Ruby-Client](https://github.com/JohnDeere/MyJohnDeereAPI-OAuth-Ruby-Client) - Ruby MyJohnDeere API client implementation.
 - [SampleData](https://github.com/JohnDeere/SampleData) - Sample datacards, shapefiles, and other files you can use for testing.
+- [SencropAPI-JavaScript-Client](https://github.com/sencrop/sencrop-js-api-client) - Sencrop API Javascript client implementation. Read and manage Sencrop weather stations.
 
 ## Farm Management Systems and Record Keeping
 


### PR DESCRIPTION
Hello 👋 
Add a link about Sencrop API and the javascript client. Sencrop is a startup doing weather stations and got an openAPI (to manage and read data from those stations).

I don't know where to put the website about the API (https://developer.sencrop.com/) , so I only put the javascript client.

Disclaimer : I'm working at Sencrop as developer 😄 